### PR TITLE
Add support for Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+.idea
 node_modules

--- a/index.js
+++ b/index.js
@@ -9,11 +9,12 @@ const supportedPlatforms = require('./package').os;
 
 const defaultOpts = {
   clear: false,
-  // osx-only options
+  // OSX options
   dependencyColor: 'blue',
-  devDependencyColor: 'yellow'
-  // windows-only options
-  // ...
+  devDependencyColor: 'yellow',
+  // Windows options
+  dependencyHidden: false,
+  devDependencyHidden: false
 };
 
 module.exports = (projectPath, opts) => {
@@ -29,8 +30,10 @@ module.exports = (projectPath, opts) => {
   const getDepInfo = deps =>
     Object.keys(deps || {}).map(dep => {
       const depPath = path.join(projectPath, 'node_modules', dep);
+      // Catch handles dependencies that are not installed
       return stat(depPath)
-        .then(stats => stats.isDirectory() && {path: depPath, module: dep});
+        .then(stats => stats.isDirectory() && {path: depPath, module: dep})
+        .catch(() => false);
     });
 
   const filterDirs = depInfo =>

--- a/lib/win32.js
+++ b/lib/win32.js
@@ -1,0 +1,149 @@
+'use strict';
+
+const pify = require('pify');
+const fs = require('fs');
+const path = require('path');
+const readdir = pify(fs.readdir);
+const stat = pify(fs.stat);
+const writeFile = pify(fs.writeFile);
+const fswin = require('fswin');
+
+/**
+ * Modify options object as needed for Windows
+ * @param opts Object
+ * @returns Object
+ */
+const handleOptions = opts => {
+  // Convert any CLI params to boolean
+  Object.keys(opts).forEach((key) => {
+    const val = opts[key];
+    if (typeof val === 'string') {
+      opts[key] = opts[key] === 'true';
+    }
+  });
+
+  if (opts.clear) {
+    opts.dependencyHidden = opts.devDependencyHidden = false;
+  }
+  return opts;
+};
+
+/**
+ * This hides all the dependencies first and writes the info file
+ * @param projectPath String
+ * @param opts Object
+ * @returns {Promise}
+ */
+const performPreAction = (projectPath, opts) => {
+  const modules = path.join(projectPath, 'node_modules');
+  const hidden = typeof opts.clear === 'boolean' ? !opts.clear : true;
+
+  const writeTextFile = writeFile(
+    path.join(modules, 'modules_hidden.txt'),
+    'You\'ve hidden modules with `john` - https://github.com/davej/john',
+    {flags: 'w'}
+  ).catch(
+    (err) => new Error('Failed to write info file', err)
+  );
+
+  return writeTextFile.then(() => readdir(modules).then((files) => Promise.all(files.map((dep) => {
+    const depPath = path.join(modules, dep);
+
+    return stat(depPath).then(
+      // Return false or the path if item is a directory
+      (stats) => stats.isDirectory() && depPath
+    );
+  })).then((files) => {
+    // Filter out files
+    const dirs = files.filter((file) => file);
+
+    // Hide all the directories
+    return Promise.all(dirs.map(
+      (dir) => new Promise((resolve, reject) => {
+        const success = fswin.setAttributesSync(dir, {IS_HIDDEN: hidden});
+        return success ? resolve(dir) : reject('Failed to hide dir ' + dir);
+      })
+    ));
+  })));
+};
+
+/**
+ * Determine whether to hide or show the passed in type of dependencies
+ * @param depType String
+ * @param deps Object
+ * @param opts Object
+ * @returns {Promise}
+ */
+const performAction = (depType, deps, opts) => {
+  const depTypeSingular = `${depType.slice(0, -3)}y`;
+  const hide = opts[`${depTypeSingular}Hidden`];
+
+  return Promise.all(deps.map(dep =>
+    new Promise((resolve, reject) => {
+      const success = fswin.setAttributesSync(dep.path, {IS_HIDDEN: hide});
+      return success ? resolve(Object.assign(dep, {hidden: hide})) : reject('Failed to modify dir ' + dep.path);
+    })
+  ));
+};
+
+/**
+ * CLI output to the user
+ * @param deps Object
+ * @param depType String
+ */
+const cliLog = (deps, depType) => {
+  deps = deps[depType];
+  if (deps.length) {
+    const hidden = deps[0].hidden;
+    const logShow = `Unhid ${depType}:`;
+    const logHide = `Hid ${deps.length} ${depType}:`;
+    console.log(hidden ? logHide : logShow);
+
+    deps.forEach(dep => console.log(`  - ${dep.module}`));
+  } else {
+    console.log(`No ${depType} found.`);
+  }
+};
+
+/**
+ * Output the helper text for using john in Windows
+ */
+const cliHelpText = () =>
+  [
+    'Usage',
+    '  > john',
+    '',
+    'Options',
+    '  --clear     Clear all hidden dependencies. [Default: false]',
+    '  --deps      Hide dependencies. [Default: false]',
+    '  --dev-deps  Hide devDependencies. [Default: false]',
+    '',
+    'Examples',
+    '  $ john',
+    '  Hid 4 dependencies',
+    '',
+    '  $ john --clear',
+    '  Unhid 4 dependencies'
+  ];
+
+/**
+ * Defines the Windows options for john
+ */
+const cliOptions = () =>
+  ({
+    alias: {
+      dep: 'dependencyHidden',
+      devDep: 'devDependencyHidden',
+      deps: 'dependencyHidden',
+      devDeps: 'devDependencyHidden'
+    }
+  });
+
+module.exports = {
+  handleOptions,
+  performPreAction,
+  performAction,
+  cliHelpText,
+  cliOptions,
+  cliLog
+};

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "john",
   "version": "1.0.1",
-  "description": "Make npm3's flat dependencies easier to find and sort on OS X",
+  "description": "Make npm3's flat dependencies easier to find and sort",
   "license": "MIT",
   "os": [
-    "darwin"
+    "darwin",
+    "win32"
   ],
   "repository": "davej/john",
   "author": {
@@ -12,6 +13,12 @@
     "email": "dave@davejeffery.com",
     "url": "twitter.com/DaveJ"
   },
+  "contributors": [
+    {
+      "name": "Enzo Martin",
+      "email": "enzo.r.martin@gmail.com"
+    }
+  ],
   "bin": "cli.js",
   "engines": {
     "node": ">=4"
@@ -20,6 +27,7 @@
     "test": "xo && ava"
   },
   "files": [
+    "lib",
     "index.js",
     "cli.js"
   ],
@@ -36,22 +44,30 @@
     "color",
     "colour",
     "finder",
+    "windows",
+    "explorer",
     "mavericks",
     "yosemite",
     "mac"
   ],
   "dependencies": {
     "chalk": "^1.1.1",
-    "finder-tag": "^1.0.2",
     "meow": "^3.6.0",
     "pify": "^2.3.0",
     "read-pkg-up": "^1.0.1"
   },
+  "optionalDependencies": {
+    "finder-tag": "^1.0.2",
+    "fswin": "^2.15.1031"
+  },
   "devDependencies": {
-    "ava": "^0.8.0",
+    "ava": "^0.11.0",
     "xo": "^0.12.1"
   },
   "xo": {
-    "space": 2
+    "space": 2,
+    "rules": {
+      "linebreak-style": 0
+    }
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -1,17 +1,33 @@
 # john [![Build Status](https://travis-ci.org/davej/john.svg?branch=master)](https://travis-ci.org/davej/john)
 
-> Make npm3's flat dependencies easier to find and sort on OS X
+> Make npm3's flat dependencies easier to find and sort
 
-npm3 has flat dependency trees, this is a good thing for many reasons.
+`npm3` has flat dependency trees, this is a good thing for many reasons.
 Unfortunately, this means your `node_modules` folder might contain hundreds (or thousands?)
 of modules and that makes it difficult to quickly debug/hack on issues with top-level dependencies.
 
-John is your man. He puts color tags on your top-level dependencies and devDependencies,
-this makes your top-level dependencies easier to find and sort in Finder. If you often use the terminal instead of finder then you can also do `ls -l | grep @` to list the folders with tags.
+# John is your man.
+> *<strong>Note</strong>: This project is currently OS X & Windows only, but if you have ideas on how something similar could be implemented on other platforms then create an issue.*
 
-*Note: This project is currently OS X only, but if you have ideas on how something similar could be implemented on other platforms then create an issue.*
+* [CLI](#cli)
+* [Using Programmatically](#using-programmatically)
+* [API](#api)
+    * [See available colors](#available-colors)
+* [Why is this called John?](#why-is-this-called-john)
+* [License](#license)
+
+#### On OSX
+He puts color tags on your top-level dependencies and devDependencies,
+this makes your top-level dependencies easier to find and sort in Finder.
+
+If you often use the terminal instead of finder then you can also do `ls -l | grep @` to list the folders with tags.
 
 <p align="center"><img src ="https://cdn.rawgit.com/davej/john/a2b79a0ffc8da296d382bd99b29977195cb3976c/usage.gif" /></p>
+
+#### On Windows
+He hides away non top-level dependencies and devDependencies, leaving you with just the modules that are important to you.
+
+<p align="center"><img src ="https://zippy.gfycat.com/ShimmeringThirstyAmericanwarmblood.gif" /></p>
 
 ## CLI
 
@@ -19,10 +35,12 @@ this makes your top-level dependencies easier to find and sort in Finder. If you
 $ npm install --global john
 ```
 
+#### OSX
+
 ```
 $ john --help
 
-  Make npm3's flat dependencies easier to find and sort on OS X
+  Make npm3's flat dependencies easier to find and sort
 
   Usage
     $ john
@@ -49,6 +67,28 @@ $ john --help
     Tagged 2 devDependencies as gray
 ```
 
+#### Windows
+
+```
+> john --help
+
+  Make npm3's flat dependencies easier to find and sort
+
+  Usage
+    > john
+
+  Options
+    --clear     Clear all hidden dependencies. [Default: false]
+    --deps      Hide dependencies. [Default: false]
+    --dev-deps  Hide devDependencies. [Default: false]
+
+  Examples
+    $ john
+    Hid 4 dependencies
+
+    $ john --clear
+    Unhid 4 dependencies
+```
 
 ## Using Programmatically
 
@@ -84,7 +124,6 @@ john('/path/to/project').then(
 )
 ```
 
-
 ## API
 
 ### john(projectPath, [options])
@@ -102,16 +141,57 @@ The path to your project's directory (that contains `package.json`).
 Type: `boolean`  
 Default: `false`
 
-Clear all tags.
+Clear all tags / show all dependencies.
+
+---
 
 ##### dependencyColor
+
+**Note:** OSX Only 
 
 Type: `string`  
 Default: `blue`
 
-Color tag to use for dependencies.
+Color tag to use for dependencies. [See available colors](#available-colors).
 
-Available Colors:
+---
+
+##### devDependencyColor
+
+**Note:** OSX Only
+
+Type: `string`  
+Default: `yellow`
+
+Color tag to use for devDependencies. [See available colors](#available-colors).
+
+---
+
+##### dependencyHidden
+
+**Note:** Windows only
+
+Type: `boolean`  
+Default: `false`
+
+Set to `true` to hide dependencies
+
+---
+
+##### devDependencyHidden
+
+**Note:** Windows only
+
+Type: `boolean`  
+Default: `false`
+
+Set to `true` to hide dev dependencies
+
+---
+
+#### Available Colors:
+**Note:** OSX only
+
 * gray
 * green
 * purple
@@ -121,16 +201,9 @@ Available Colors:
 * orange
 * clear
 
-##### devDependencyColor
-
-Type: `string`  
-Default: `yellow`
-
-Color tag to use for devDependencies. See available colors above.
-
 ## Why is this called John?
 
-'John' like 'Johnny' like 'Johnny Depp' like 'Dep[p]endency'. Pfft, mainly because it was short, simple and not already taken.
+Asking the important questions! 'John' like 'Johnny' like 'Johnny Depp' like 'Dep[p]endency'. Pfft, mainly because it was short, simple and not already taken.
 
 ## License
 

--- a/test/win32.js
+++ b/test/win32.js
@@ -1,8 +1,60 @@
 import test from 'ava';
+import fn from '../';
+import path from 'path';
+const rootDir = path.resolve(__dirname, '../');
 
 if (process.platform === 'win32') {
-  test('simple', t =>
-    t.pass()
+  test('simple run with defaults', t =>
+    fn(rootDir).then(files => {
+      t.ok(files.dependencies);
+      t.ok(files.devDependencies);
+      t.ok(files.dependencies[0].path.includes(rootDir));
+      t.is(files.dependencies[0].hidden, false);
+      t.is(files.devDependencies[0].hidden, false);
+    })
+  );
+
+  test('launched from within node_modules dir', t =>
+    fn(path.join(rootDir, 'node_modules')).then(files => {
+      t.ok(files.dependencies);
+      t.ok(files.devDependencies);
+      t.ok(files.dependencies[0].path.includes(rootDir));
+      t.is(files.dependencies[0].hidden, false);
+      t.is(files.devDependencies[0].hidden, false);
+    })
+  );
+
+  test('hide dependencies', t =>
+    fn(rootDir, {
+      dependencyHidden: true,
+      devDependencyHidden: false
+    }).then(files => {
+      t.ok(files.dependencies);
+      t.ok(files.devDependencies);
+      t.is(files.dependencies[0].hidden, true);
+      t.is(files.devDependencies[0].hidden, false);
+    })
+  );
+
+  test('hide devDependencies', t =>
+    fn(rootDir, {
+      dependencyHidden: false,
+      devDependencyHidden: true
+    }).then(files => {
+      t.ok(files.dependencies);
+      t.ok(files.devDependencies);
+      t.is(files.dependencies[0].hidden, false);
+      t.is(files.devDependencies[0].hidden, true);
+    })
+  );
+
+  test.after('clear and show all', t =>
+    fn(rootDir, {clear: true}).then(files => {
+      t.ok(files.dependencies);
+      t.ok(files.devDependencies);
+      t.is(files.dependencies[0].hidden, false);
+      t.is(files.devDependencies[0].hidden, false);
+    })
   );
 } else {
   test('skip win32 tests', t =>


### PR DESCRIPTION
- Hides folders instead of coloring them
- Adds a .txt file in `node_modules` to remind the user they've hidden directories with john
- Makes `finder-tag` module optional
- Add optional `fswin` module

Need to make the tests run as well, and update the readme, but wanted to get input on it before doing that.

Since Windows doesn't support Tags, I thought a decent alternative would be to hide the folders. It does cause some slight differences with the options though since you need to specify whether or not to hide the dependencies.