### PR TITLE
Refactor to use helpers instead of repeating functions that do the same thing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 node_modules
+typings

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,3 @@
-# Test against this version of Node.js
 environment:
   matrix:
   - nodejs_version: "4"

--- a/lib/darwin.js
+++ b/lib/darwin.js
@@ -3,6 +3,11 @@
 const tag = require('finder-tag');
 const chalk = require('chalk');
 
+/**
+ * Set colors to `clear` if the clear option is Set
+ * @param  {Object} opts
+ * @return {Object} opts
+ */
 const handleOptions = opts => {
   if (opts.clear) {
     opts.dependencyColor = opts.devDependencyColor = 'clear';
@@ -10,6 +15,13 @@ const handleOptions = opts => {
   return opts;
 };
 
+/**
+ * Tag dependency folders with colors
+ * @param  {String} depType 'dependencies' or 'devDependencies'
+ * @param  {Array.<Object>} deps
+ * @param  {Object} opts
+ * @return {Promise.<Array.<Object>>}
+ */
 const performAction = (depType, deps, opts) => {
   // tag dependency directories with corresponding color
   const depTypeSingular = `${depType.slice(0, -3)}y`;
@@ -24,6 +36,11 @@ const performAction = (depType, deps, opts) => {
   ));
 };
 
+/**
+ * CLI output to the user
+ * @param  {Array.<Object>} deps
+ * @param  {String} depType 'dependencies' or 'devDependencies'
+ */
 const cliLog = (deps, depType) => {
   const terminalColor = color => chalk[color] ? chalk[color](color) : color;
 
@@ -40,6 +57,9 @@ const cliLog = (deps, depType) => {
   deps.forEach(dep => console.log(`  - ${dep.module}`));
 };
 
+/**
+ * Output the CLI helper text for OS X
+ */
 const cliHelpText = () =>
   [
     'Usage',
@@ -64,6 +84,9 @@ const cliHelpText = () =>
     '  Tagged 2 devDependencies as gray'
   ];
 
+/**
+ * Defines the OS X CLI options
+ */
 const cliOptions = () =>
   ({
     alias: {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,0 +1,33 @@
+const pify = require('pify');
+const path = require('path');
+const stat = pify(require('fs').stat);
+
+const arrayify = arr => Array.isArray(arr) ? arr : Object.keys(arr || {});
+
+const getDepPaths = (modulePath, deps) =>
+  arrayify(deps).map(dep => ({
+    path: path.join(modulePath, dep),
+    module: dep
+  }));
+
+const checkDeps = deps =>
+  deps.map(dep =>
+    stat(dep.path)
+      // Check if dep.path is directory
+      .then(stats => stats.isDirectory() && dep)
+      // Catch handles dependencies that are not installed
+      .catch(() => false)
+  );
+
+const filterDeps = depInfo =>
+  // Filter out `deps` with value `false`
+  Promise.all(depInfo).then(deps => deps.filter(dep => Boolean(dep)));
+
+const getDeps = (modulePath, deps) =>
+  filterDeps(checkDeps(getDepPaths(modulePath, deps)));
+
+module.exports = {
+  filterDeps,
+  getDeps,
+  getDepPaths
+};

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -2,14 +2,31 @@ const pify = require('pify');
 const path = require('path');
 const stat = pify(require('fs').stat);
 
-const arrayify = arr => Array.isArray(arr) ? arr : Object.keys(arr || {});
+/**
+ * Convert object to array (or pass-through is already array)
+ * @param  {Array|Object} arr
+ * @return {Array} arr
+ */
+const toArray = arr =>
+  Array.isArray(arr) ? arr : Object.keys(arr || {});
 
+/**
+ * get path and module name for each dependency
+ * @param  {String} modulePath path to `node_modules`
+ * @param  {Array|Object} deps
+ * @return {Array<Object>} deps
+ */
 const getDepPaths = (modulePath, deps) =>
-  arrayify(deps).map(dep => ({
+  toArray(deps).map(dep => ({
     path: path.join(modulePath, dep),
     module: dep
   }));
 
+/**
+ * check if `dep.path` exists and is directory otherwise return false
+ * @param  {Array<Object>} deps
+ * @return {Promise.<Array.<Object|Boolean>>}
+ */
 const checkDeps = deps =>
   deps.map(dep =>
     stat(dep.path)
@@ -19,10 +36,21 @@ const checkDeps = deps =>
       .catch(() => false)
   );
 
-const filterDeps = depInfo =>
+/**
+ * remove dependencies that are falsy
+ * @param  {Promise.<Array.<Object|Boolean>>} deps
+ * @return {Promise.<Array.<Object>>}
+ */
+const filterDeps = deps =>
   // Filter out `deps` with value `false`
-  Promise.all(depInfo).then(deps => deps.filter(dep => Boolean(dep)));
+  Promise.all(deps).then(resolvedDeps => resolvedDeps.filter(dep => Boolean(dep)));
 
+/**
+ * get dependency paths and filter out invalid paths
+ * @param  {String}  module  Path path to `node_modules` dir
+ * @param  {Array|Object} deps
+ * @return {Promise.<Array.<Object>>}
+ */
 const getDeps = (modulePath, deps) =>
   filterDeps(checkDeps(getDepPaths(modulePath, deps)));
 

--- a/lib/win32.js
+++ b/lib/win32.js
@@ -3,8 +3,8 @@
 const pify = require('pify');
 const fs = require('fs');
 const path = require('path');
+const helpers = require('./helpers');
 const readdir = pify(fs.readdir);
-const stat = pify(fs.stat);
 const writeFile = pify(fs.writeFile);
 const fswin = require('fswin');
 
@@ -15,7 +15,7 @@ const fswin = require('fswin');
  */
 const handleOptions = opts => {
   // Convert any CLI params to boolean
-  Object.keys(opts).forEach((key) => {
+  Object.keys(opts).forEach(key => {
     const val = opts[key];
     if (typeof val === 'string') {
       opts[key] = opts[key] === 'true';
@@ -27,6 +27,21 @@ const handleOptions = opts => {
   }
   return opts;
 };
+
+/**
+ * Sets the value of the `hidden` attribute on dependency paths
+ * @param deps Object
+ * @param hidden Boolean
+ * @returns {Promise}
+ */
+const setHiddenAttr = (deps, hidden) =>
+  Promise.all(
+    deps.map(dep =>
+      fswin.setAttributesSync(dep.path, {IS_HIDDEN: hidden}) ?
+        Promise.resolve(Object.assign(dep, {hidden})) :
+        Promise.reject(new Error(`Failed to modify dir attr: ${dep.path}`))
+    )
+  );
 
 /**
  * This hides all the dependencies first and writes the info file
@@ -42,29 +57,12 @@ const performPreAction = (projectPath, opts) => {
     path.join(modules, 'modules_hidden.txt'),
     'You\'ve hidden modules with `john` - https://github.com/davej/john',
     {flags: 'w'}
-  ).catch(
-    (err) => new Error('Failed to write info file', err)
   );
 
-  return writeTextFile.then(() => readdir(modules).then((files) => Promise.all(files.map((dep) => {
-    const depPath = path.join(modules, dep);
-
-    return stat(depPath).then(
-      // Return false or the path if item is a directory
-      (stats) => stats.isDirectory() && depPath
-    );
-  })).then((files) => {
-    // Filter out files
-    const dirs = files.filter((file) => file);
-
-    // Hide all the directories
-    return Promise.all(dirs.map(
-      (dir) => new Promise((resolve, reject) => {
-        const success = fswin.setAttributesSync(dir, {IS_HIDDEN: hidden});
-        return success ? resolve(dir) : reject('Failed to hide dir ' + dir);
-      })
-    ));
-  })));
+  return writeTextFile
+    .then(() => readdir(modules))
+    .then(files => helpers.getDeps(modules, files))
+    .then(deps => setHiddenAttr(deps, hidden));
 };
 
 /**
@@ -76,14 +74,9 @@ const performPreAction = (projectPath, opts) => {
  */
 const performAction = (depType, deps, opts) => {
   const depTypeSingular = `${depType.slice(0, -3)}y`;
-  const hide = opts[`${depTypeSingular}Hidden`];
+  const hidden = opts[`${depTypeSingular}Hidden`];
 
-  return Promise.all(deps.map(dep =>
-    new Promise((resolve, reject) => {
-      const success = fswin.setAttributesSync(dep.path, {IS_HIDDEN: hide});
-      return success ? resolve(Object.assign(dep, {hidden: hide})) : reject('Failed to modify dir ' + dep.path);
-    })
-  ));
+  return setHiddenAttr(deps, hidden);
 };
 
 /**


### PR DESCRIPTION
`index.js` and `win32.js` share functions that effectively do the same thing so I abstracted them out as helper functions.

@EnzoMartin: Does this look ok to you? Tests all pass on Windows.
